### PR TITLE
#130: define this._id instead of create property

### DIFF
--- a/src/leader-line.js
+++ b/src/leader-line.js
@@ -3371,7 +3371,7 @@
     props.curStats.show_effect = DEFAULT_SHOW_EFFECT;
     props.curStats.show_animOptions = copyTree(SHOW_EFFECTS[DEFAULT_SHOW_EFFECT].defaultAnimOptions);
 
-    Object.defineProperty(this, '_id', {value: ++insId});
+    this._id = ++insId;
     props._id = this._id;
     insProps[this._id] = props;
 


### PR DESCRIPTION
everywhere in code _id property used like this._id, but in this._id in undefined. as result of this in DOM we have all leader lines with NOT unique id of HTML element, like: leader-line-undefined-some-prop, and browser will hide all lines except first parsed (with same element id)